### PR TITLE
Readme Updates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@
      ```
 1. Launch your new store and deploy the database automatically:
    ```bash
-   lando start
+   lando start or lando rebuild (rebuild only to force install missing php extension.  Usually happens when you havnt renamed the app and youve got existing containers hangin around. lando list to check)
    lando composer install
    lando magento:setup:quick # Optional: ----use-sample-data 
    ```

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,16 @@
    lando magento:setup:quick # Optional: ----use-sample-data 
    ```
 
-That's it! Your store is ready for development: https://magento2.lndo.site/  
+You should now be able to access your local installation of Magento: https://magento2.lndo.site/ (or whatever proxy value you have set in your lando.base.yaml file)
+
+If you have followed the quicksetup without providing any other parameters be aware your Magento database will have no base_url or base_url_secure values yet.  This can and in most cases will cause a redirect loop when acessing the Magento admin page. 
+
+All lndo.site sub-domains https://magento2.lndo.site/ are real URL's, therefor wont be available offline.
+Alternativly localhost.xxxx URL's are available offline but change with every lando rebuild.  If your running localhost URL's you will need to update your Magento URL's after each rebuild and provide the new localhost values.
+
+lando magento setup:store-config:set --base-url="" --base-url-secure=""
+
+
 
 # Customizing Lando
 

--- a/readme.md
+++ b/readme.md
@@ -47,8 +47,9 @@ If you have followed the quicksetup without providing any other parameters be aw
 All lndo.site sub-domains https://magento2.lndo.site/ are real URL's, therefor wont be available offline.
 Alternativly localhost.xxxx URL's are available offline but change with every lando rebuild.  If your running localhost URL's you will need to update your Magento URL's after each rebuild and provide the new localhost values.
 
-lando magento setup:store-config:set --base-url="" --base-url-secure=""
-
+   ```bash
+   lando magento setup:store-config:set --base-url="" --base-url-secure=""
+   ```
 
 
 # Customizing Lando


### PR DESCRIPTION
1. Added an optional step to the quick setup when running lando start.  A common stumbling block is if you have previously run lando without changing any of the lando.yaml values you will run into the php extension error because this command is only run the first time you use the lando start command.  It is possible to run lando start have the php extension fail but the containers still build.

2. When following quick setup the Magento Admin is inaccessible until base and base secure urls are provided.  Added instruction to the readme for setting the URLs and what to look out for when using the lndo.site subdomain offline.  NB - Its worth considering this could potentially be taken care of in the build process  by running a build_as_root cmd and providing the latest build URL to magento.  




